### PR TITLE
Update Dockerfile to use newer Debian base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-mirage.sh
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-mirage.sh
 script: bash -ex .travis-mirage.sh
 sudo: required
 dist: trusty
@@ -20,4 +20,4 @@ addons:
     - time
     - libxen-dev
 env:
-  - FORK_USER=talex5 FORK_BRANCH=unikernel OCAML_VERSION=4.04 MIRAGE_BACKEND=xen PINS="mirage-nat:https://github.com/talex5/mirage-nat.git#lru"
+  - OCAML_VERSION=4.04 MIRAGE_BACKEND=xen PINS="mirage-nat:https://github.com/talex5/mirage-nat.git#lru"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # It will probably still work on newer images, though, unless Debian 8
 # changes some compiler optimisations (unlikely).
 #FROM ocaml/opam:debian-8_ocaml-4.03.0
-FROM ocaml/opam@sha256:48c025a4ec2e6ff6dcb4c14f8cae0f332a090fa1ed677170912c4a48627778ab
+FROM ocaml/opam@sha256:66f9d402ab6dc00c47d2ee3195ab247f9c1c8e7e774197f4fa6ea2a290a3ebbc
 
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the


### PR DESCRIPTION
Was failing with

```
E: Failed to fetch http://security.debian.org/pool/updates/main/x/xen/libxenstore3.0_4.4.1-9+deb8u8_amd64.deb  404  Not Found [IP: 212.211.132.32 80]
```