### PR TITLE
Use Git master for shared-memory-ring and netchannel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git
 _build
+*.xen
+*.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,8 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-mirage.sh
-script: bash -ex .travis-mirage.sh
+script:
+  - echo 'ADD . /home/opam/qubes-mirage-firewall' >> Dockerfile
+  - echo 'RUN sudo chown -R opam /home/opam/qubes-mirage-firewall' >> Dockerfile
+  - docker build -t qubes-mirage-firewall .
+  - docker run --rm -i qubes-mirage-firewall
 sudo: required
 dist: trusty
-addons:
-  apt:
-    sources:
-    - avsm
-    packages:
-    - ocaml
-    - ocaml-base
-    - ocaml-native-compilers
-    - ocaml-compiler-libs
-    - ocaml-interp
-    - ocaml-base-nox
-    - ocaml-nox
-    - camlp4
-    - camlp4-extra
-    - time
-    - libxen-dev
-env:
-  - OCAML_VERSION=4.04 MIRAGE_BACKEND=xen

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,18 @@
 # It will probably still work on newer images, though, unless Debian 8
 # changes some compiler optimisations (unlikely).
 #FROM ocaml/opam:debian-8_ocaml-4.04.2
-FROM ocaml/opam@sha256:17a527319b850bdaf6759386a566dd088a053758b6d0603712dbcb10ad62f86c
+FROM ocaml/opam@sha256:17143ad95a2e944758fd9de6ee831e9af98367455cd273b17139c38dcb032f09
 
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN cd opam-repository && git fetch origin && git reset --hard ad6348231fa14e1d9df724db908a1b7fe07d3ab9 && opam update
+RUN cd opam-repository && git reset --hard 26fc7c2d5eb5041b7348e28e8300d376a1c31a62 && opam update
 
 RUN sudo apt-get install -y m4 libxen-dev
-RUN opam install -y vchan xen-gnt mirage-xen-ocaml mirage-xen-minios io-page mirage-xen mirage mirage-nat
+# TODO: remove this once the new versions are released (smr>2.0.1 and mnx>1.7.1)
+RUN opam pin add -yn --dev netchannel
+RUN opam pin add -yn --dev shared-memory-ring
+RUN opam install -y vchan xen-gnt mirage-xen-ocaml mirage-xen-minios io-page mirage-xen mirage mirage-nat mirage-qubes
 RUN mkdir /home/opam/qubes-mirage-firewall
 ADD config.ml /home/opam/qubes-mirage-firewall/config.ml
 WORKDIR /home/opam/qubes-mirage-firewall

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To configure your new firewall using the Qubes Manager GUI:
 - Click `OK` to create the VM.
 - Go to the VM settings, and look in the `Advanced` tab:
   - Set the kernel to `mirage-firewall`.
-  - Turn off memory balancing and set the memory to 20 MB or so (you might have to fight a bit with the Qubes GUI to get it this low).
+  - Turn off memory balancing and set the memory to 32 MB or so (you might have to fight a bit with the Qubes GUI to get it this low).
   - Set VCPUs (number of virtual CPUs) to 1.
 
 You can run `mirage-firewall` alongside your existing `sys-firewall` and you can choose which AppVMs use which firewall using the GUI.

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,4 +5,4 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: 4b24bab81f9c1b14bafabd9725428456c4d6eaff0ef5cefd032a59b9f4021693"
+echo "SHA2 last known: 2cad66c4b83817cdd1650f174586fd4daab7b7c271abd62844de6e6a17200750"

--- a/client_net.ml
+++ b/client_net.ml
@@ -106,7 +106,7 @@ let add_client ~router vif client_ip =
           add_vif vif ~client_ip ~router ~cleanup_tasks
         )
         (fun ex ->
-           Log.warn (fun f -> f "Error connecting client %a: %s"
+           Log.warn (fun f -> f "Error with client %a: %s"
                         Dao.ClientVif.pp vif (Printexc.to_string ex));
            return ()
         )


### PR DESCRIPTION
This adds support for HVM and disposable domains.

Also, update the suggested RAM allocation slightly as 20 MB can be too small with lots of VMs.

Fixes #16.
Fixes #9.