### PR TITLE
Update last known build hash

### DIFF
--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,4 +5,4 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: dbc245bc425537082e64cf4b4822ce300ddeab10a272a009881e0bd22e06455a"
+echo "SHA2 last known: 3605a97fbdb9e699a9ceb9e43def8a3cdd04e5cefb48b5824df8f55e7f949203"


### PR DESCRIPTION
I noticed the hash was different, which raised an alarm bell. It turned out to be due to changes which affect the build.

Hash replaced in the docker build file.

P.S. thank you for writing mirage-firewall and teaching us the unikernel way!